### PR TITLE
Rebalances the bluespace compression kit

### DIFF
--- a/modular_towelstation/modules/compression_kit/compressionkit.dm
+++ b/modular_towelstation/modules/compression_kit/compressionkit.dm
@@ -90,8 +90,8 @@
 /obj/item/compressionkit/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(istype(I, /obj/item/stack/telecrystal))
-		var/obj/item/stack/telecrystal/T = I
-		charges += 1 * T.amount
+		var/obj/item/stack/telecrystal/crystal = I
+		charges += 1 * crystal.amount
 		to_chat(user, span_notice("You insert [I] into [src]. It now has [charges] charges."))
 		qdel(I)
 

--- a/modular_towelstation/modules/compression_kit/compressionkit.dm
+++ b/modular_towelstation/modules/compression_kit/compressionkit.dm
@@ -11,13 +11,13 @@
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
-	var/charges = 5
+	var/charges = 3
 	// var/damage_multiplier = 0.2 Not in use yet.
 	var/mode = COMPRESSION_MODE
 
 /obj/item/compressionkit/examine(mob/user)
 	. = ..()
-	. += span_notice("It has [charges] charges left. Recharge with bluespace crystals.")
+	. += span_notice("It has [charges] charges left. Recharge with telecrystals.")
 	. += span_notice("Use in-hand to swap toggle compress mode.")
 
 /obj/item/compressionkit/attack_self(mob/user)
@@ -62,7 +62,7 @@
 	else
 		if(charges == 0)
 			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
-			to_chat(user, span_notice("The bluespace compression kit is out of charges! Recharge it with bluespace crystals."))
+			to_chat(user, span_notice("The bluespace compression kit is out of charges! Recharge it with telecrystals."))
 			return
 	if(istype(target, /obj/item))
 		var/obj/item/O = target
@@ -89,9 +89,9 @@
 
 /obj/item/compressionkit/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(istype(I, /obj/item/stack/ore/bluespace_crystal))
-		var/obj/item/stack/ore/bluespace_crystal/B = I
-		charges += 2 * B.amount
+	if(istype(I, /obj/item/stack/telecrystal))
+		var/obj/item/stack/telecrystal/T = I
+		charges += 1 * T.amount
 		to_chat(user, span_notice("You insert [I] into [src]. It now has [charges] charges."))
 		qdel(I)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After receiving feedback and seeing it used in-game for myself, I've realized that it is far too strong. So I have changed the charge amount of it to 3 instead of 5. Additionally I have made it so you have to use telecrystals to recharge it instead of bluespace crystals.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Towelstation Roleplay Experience
Nerfs an insanely overpowered traitor item.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bluespace compression kits now require telecrystals to be recharged and have three max charges instead of five.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
